### PR TITLE
Feature/docker build validation

### DIFF
--- a/applications/stages/docker-app-build-validation.yaml
+++ b/applications/stages/docker-app-build-validation.yaml
@@ -1,6 +1,6 @@
 parameters:
   # docker stage to copy test results from (for multi-stage builds)
-  - name: testResultStage
+  - name: testResultsStage
     type: string
     default: none
 
@@ -39,14 +39,14 @@ stages:
         variables:
           testResultsFolder: '$(Build.ArtifactStagingDirectory)/test-results'
         steps:
-          - ${{ if ne(parameters.testResultStage, 'none') }}:
+          - ${{ if ne(parameters.testResultsStage, 'none') }}:
             - task: Docker@2
               displayName: Run Tests
               env:
                 DOCKER_BUILDKIT: 1
               inputs:
                 command: build
-                arguments: '--target ${{ parameters.testResultStage }} --output type=local,dest=$(testResultsFolder)'
+                arguments: '--target ${{ parameters.testResultsStage }} --output type=local,dest=$(testResultsFolder)'
                 DockerFile: '**/Dockerfile'
 
             - ${{ if ne(parameters.testResultsFormat, 'none') }}:

--- a/applications/stages/docker-app-build-validation.yaml
+++ b/applications/stages/docker-app-build-validation.yaml
@@ -26,7 +26,7 @@ parameters:
 
   # flag to enable coverage results publishing
   - name: publishCoverageResults
-    type: bool
+    type: boolean
     default: false
   
 

--- a/applications/stages/docker-app-build-validation.yaml
+++ b/applications/stages/docker-app-build-validation.yaml
@@ -19,15 +19,15 @@ parameters:
     type: string
     default: cobertura-coverage.xml
 
-  # format of the coverage results file
-  - name: coverageResultsFormat
-    type: string
-    default: none
-
   # path to source files referenced in the coverage results
   - name: coveragePathToSources
     type: string
     default: $(Build.SourcesDirectory)
+
+  # flag to enable coverage results publishing
+  - name: publishCoverageResults
+    type: bool
+    default: false
   
 
 stages:
@@ -56,7 +56,7 @@ stages:
                   testResultsFiles: '$(testResultsFolder)/${{ parameters.testResultsFile }}'
                   testResultsFormat: ${{ parameters.testResultsFormat }}
 
-            - ${{ if ne(parameters.coverageResultsFormat, 'none') }}:
+            - ${{ if eq(parameters.publishCoverageResults, true) }}:
               - task: PublishCodeCoverageResults@2
                 displayName: Publish Code Coverage
                 inputs:

--- a/applications/stages/docker-app-build-validation.yaml
+++ b/applications/stages/docker-app-build-validation.yaml
@@ -1,0 +1,70 @@
+parameters:
+  # docker stage to copy test results from (for multi-stage builds)
+  - name: testResultStage
+    type: string
+    default: none
+
+  # path to the test results file
+  - name: testResultsFile
+    type: string
+    default: junit.xml
+
+  # format of the test results file
+  - name: testResultsFormat
+    type: string
+    default: none
+
+  # path to the coverage results file
+  - name: coverageResultsFile
+    type: string
+    default: cobertura-coverage.xml
+
+  # format of the coverage results file
+  - name: coverageResultsFormat
+    type: string
+    default: none
+
+  # path to source files referenced in the coverage results
+  - name: coveragePathToSources
+    type: string
+    default: $(Build.SourcesDirectory)
+  
+
+stages:
+  - stage: build_validation
+    displayName: Build Validation
+    jobs:
+      - job: build
+        displayName: Build
+        variables:
+          testResultsFolder: '$(Build.ArtifactStagingDirectory)/test-results'
+        steps:
+          - ${{ if ne(parameters.testResultStage, 'none') }}:
+            - task: Docker@2
+              displayName: Run Tests
+              env:
+                DOCKER_BUILDKIT: 1
+              inputs:
+                command: build
+                arguments: '--target ${{ parameters.testResultStage }} --output type=local,dest=$(testResultsFolder)'
+                DockerFile: '**/Dockerfile'
+
+            - ${{ if ne(parameters.testResultsFormat, 'none') }}:
+              - task: PublishTestResults@2
+                displayName: Publish Test Results
+                inputs:
+                  testResultsFiles: '$(testResultsFolder)/${{ parameters.testResultsFile }}'
+                  testResultsFormat: ${{ parameters.testResultsFormat }}
+
+            - ${{ if ne(parameters.coverageResultsFormat, 'none') }}:
+              - task: PublishCodeCoverageResults@2
+                displayName: Publish Code Coverage
+                inputs:
+                  summaryFileLocation: '$(testResultsFolder)/${{ parameters.coverageResultsFile }}'
+                  pathToSources: ${{ parameters.coveragePathToSources }}
+        
+          - task: Docker@2
+            displayName: Build Image
+            inputs:
+              command: build
+              Dockerfile: '**/Dockerfile'


### PR DESCRIPTION
Add generic build validation template for docker builds

Users can optionally specify a `testResultsStage`, which is an OCI layer containing any test results to export

for example
```
FROM scratch AS test-results

COPY --from=test /usr/src/app/coverage.xml cobertura-coverage.xml
COPY --from=test /usr/src/app/junit.xml junit.xml
```